### PR TITLE
Advance RFC #0029 to Stage Released

### DIFF
--- a/text/0029-foo-bar.md
+++ b/text/0029-foo-bar.md
@@ -10,5 +10,6 @@ teams:
 prs:
   accepted: 'https://github.com/kategengler/playground-ghas/pull/29'
   ready-for-release: 'https://github.com/kategengler/playground-ghas/pull/30'
+  released: 'https://github.com/kategengler/playground-ghas/pull/31'
 ---
 # My RFC

--- a/text/0029-foo-bar.md
+++ b/text/0029-foo-bar.md
@@ -1,5 +1,5 @@
 ---
-stage: ready-for-release
+stage: released
 start-date:
 release-date: Unreleased
 release-versions:


### PR DESCRIPTION
# Advance #0029 to the [Released Stage](https://github.com/emberjs/rfcs#released)

## Summary

This pull request is advancing the RFC to the [Released Stage](https://github.com/emberjs/rfcs#released).

- PR to Accepted Stage: #0029
- [PR to Ready For Release Stage](https://github.com/kategengler/playground-ghas/pull/30)

<details>
<summary>Released Stage Summary</summary>

The work is published. If it is codebase-related work, it is in a stable version
of the relevant package(s). If there are any critical deviations from the 
original RFC, they are briefly noted at the top of the RFC.

If the work for an RFC is spread across multiple releases of Ember or other 
packages, the RFC is considered to be in the Released stage when all features 
are available in stable releases and those packages and versions are noted in 
the RFC frontmatter.

Ember's RFC process can be used for process and work plans that are not about 
code. Some examples include Roadmap RFCs, changes to the RFC process itself, 
and changes to learning resources. When such an RFC is a candidate for Released, 
the work should be shipped as described, and the result should presented to the 
team with the intent of gathering feedback about whether anything is missing. 
If there is agreement that the work is complete, the RFC may be marked "Released" 
and a date is provided instead of a version.

An RFC is moved into "Released" when the above is verified by consensus of the 
relevant team(s) via a PR to update the stage.
</details>

## Actions

- [ ] The work is published in stable versions of the relevant package(s)
- [ ] Deviations from the original RFC are noted at the top of the RFC
- [ ] Release packages and dates are updated in the RFC frontmatter